### PR TITLE
Added compatibility for Qt6 and some sanity checks

### DIFF
--- a/ui_editor.py
+++ b/ui_editor.py
@@ -14,6 +14,9 @@ def display_image(editor, img_filename, image_dest_field):
 
 def search_image(editor):
     query = utils.get_note_query(editor.note)
+    if not query:
+        return
+
     image_url = search.get_result_by_query(query)
     if not image_url:
         utils.report("Couldn't find images for query '{}' :(".format(query))

--- a/ui_menu.py
+++ b/ui_menu.py
@@ -1,3 +1,10 @@
+try:
+    from PyQt6 import QtCore
+    qt_version = 6
+except ImportError:
+    from PyQt5 import QtCore
+    qt_version = 5
+
 from aqt import mw
 from aqt.utils import qconnect
 from aqt.qt import *
@@ -23,8 +30,12 @@ def settings_dialog():
     box_image.addWidget(label_image)
     box_image.addWidget(text_image)
 
-    ok = QDialogButtonBox(QDialogButtonBox.Ok)
-    cancel = QDialogButtonBox(QDialogButtonBox.Cancel)
+    if qt_version == 5:
+        ok = QDialogButtonBox(QDialogButtonBox.Ok)
+        cancel = QDialogButtonBox(QDialogButtonBox.Cancel)
+    else:
+        ok = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        cancel = QDialogButtonBox(QDialogButtonBox.StandardButton.Cancel)
 
     def init_configui():
         config = utils.get_config()
@@ -33,8 +44,8 @@ def settings_dialog():
 
     def save_config():
         config = utils.get_config()
-        config["image_field"] = text_query.text()
-        config["query_field"] = text_image.text()
+        config["query_field"] = text_query.text()
+        config["image_field"] = text_image.text()
         mw.addonManager.writeConfig(__name__, config)
 
         dialog.close()
@@ -55,7 +66,10 @@ def settings_dialog():
 
     layout_everything()
 
-    dialog.exec_()
+    if qt_version == 5:
+        dialog.exec_()
+    else:
+        dialog.exec()
 
 
 def init_menu():

--- a/utils.py
+++ b/utils.py
@@ -19,10 +19,18 @@ def get_config():
 
 
 def get_note_query(note):
-    field_names = mw.col.models.fieldNames(note.model())
+    field_names = mw.col.models.fieldNames(note.model())    
+    query_field_name = get_config().get("query_field", "")
+    
+    if query_field_name in field_names:
+        query_field = field_names.index(query_field_name)
+        return note.fields[query_field]
+    
+    if importlib.util.find_spec("aqt"):
+        from aqt.utils import showWarning
+        showWarning(f"Field '{query_field_name}' is absent, please check addon settings. Existing fields: {field_names}", title="Anki Image Search v2 Addon")
 
-    query_field = field_names.index(get_config()["query_field"])
-    return note.fields[query_field]
+    return None
 
 
 def get_note_image_field_index(note):


### PR DESCRIPTION
This PR addresses two issues in the code of the addon:

* Error handling in the get_note_query function where a ValueError was raised if the configured query field ("query_field") was not present in the note's model fields.
* Compatibility updates for Qt6, ensuring that the code runs smoothly across both Qt5 and Qt6 environments.